### PR TITLE
Fix alert processing logic and Helm chart defaults

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -46,12 +46,15 @@ spec:
       - name: alert-proxy
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         command: ["uwsgi"]
-        args: ["--ini", "/opt/alert-proxy/src/config/uwsgi.ini", "--daemonize=alert-proxy"]
+        args: ["--ini", "/opt/alert-proxy/src/config/uwsgi.ini"]
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        ports:
+        - containerPort: 8000
+          name: http
         env: # Re-added: Injecting secrets as environment variables from existing Secrets
         - name: CORE_ACCOUNT_NUMBER
           valueFrom:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -46,7 +46,7 @@ config:
 livenessProbe:
   httpGet:
     path: /process
-    port: 80
+    port: 8000
   initialDelaySeconds: 10
   periodSeconds: 10
   timeoutSeconds: 5
@@ -54,7 +54,7 @@ livenessProbe:
 readinessProbe:
   httpGet:
     path: /process
-    port: 80
+    port: 8000
   initialDelaySeconds: 10
   periodSeconds: 10
   timeoutSeconds: 5

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ uWSGI==2.0.28
 requests==2.32.3
 flask-request-id-header==0.1.1
 PyYAML==6.0.2
+pytest==8.3.2

--- a/src/apps/process_alert/process_alert.py
+++ b/src/apps/process_alert/process_alert.py
@@ -75,9 +75,8 @@ class ProcessAlert(MethodView):
         current_app.logger.info(f"BEGIN alert processing......")
         content_type = request.headers.get('Content-Type')
 
-        # set the request-id for inclusion into the core ticket
-        if has_request_context():
-            request_id = request.environ.get("HTTP_X_REQUEST_ID")
+        # Set the request-id for inclusion into the core ticket
+        request_id = request.environ.get("HTTP_X_REQUEST_ID") if has_request_context() else None
 
         if content_type == 'application/json':
             alert_data = request.get_json(silent=True)
@@ -93,29 +92,26 @@ class ProcessAlert(MethodView):
             current_app.logger.info(f"END alert processing......")
             return jsonify({"message": "Content-Type is not application/json"}), 400
 
-        # set the request-id for inclusion into the core ticket
-        if has_request_context():
-            request_id = request.environ.get("HTTP_X_REQUEST_ID")
-
         # Configure top-level alert variables
         a_name = alert_data['commonLabels'].get('alertname', "NONE")
         a_status = "ALARM" if alert_data['status'] == "firing" else "OK" if alert_data['status'] == "resolved" else "OK"
         a_subject = alert_data['commonAnnotations'].get('summary', 'SUMMARY')
         a_description = alert_data['commonAnnotations'].get('description', 'DESCRIPTION')
-        a_oversserID = alert_data['commonLabels'].get('oversserID', settings.alert_proxy_config.core_overseer_id)
+        a_overseerID = alert_data['commonLabels'].get('overseerID', settings.alert_proxy_config.core_overseer_id)
         a_coreAccountID = alert_data['commonLabels'].get('coreAccountID', settings.alert_proxy_config.account_secret)
         a_secret = settings.alert_proxy_config.account_secret
 
         # loop through all alerts contained in the receiver webhook payload
         alerts = alert_data.get('alerts', [])
         current_app.logger.info(f"Received alert dump.  Total number of alerts to process: { len(alerts) }")
-        count = 0;
+        count = 0
         for alert in alerts:
             count += 1
-            a_fingerprint = alert.get('fingerprint','UNKNOWN')
-            a_severity = alert.get('severity', 'warning')
+            a_fingerprint = alert.get('fingerprint', 'UNKNOWN')
+            a_severity = alert.get('labels', {}).get('severity', 'warning')
             current_app.logger.info(f"Processing { count } of { len(alerts) } ...")
-            alert['labels']['request-id'] = request_id
+            if request_id:
+                alert.setdefault('labels', {})['request-id'] = request_id
             current_app.logger.debug(f"Alert { count } payload: { alert }")
             if settings.alert_proxy_config.alert_verification:
                 if self._is_alert_still_firing(a_fingerprint):
@@ -125,20 +121,24 @@ class ProcessAlert(MethodView):
                     continue
             current_app.logger.info(f"Formatting alert for watchman ingestion")
             if a_severity == "warning":
-                w_url = f"https://watchman.api.manage.rackspace.com/v1/hybrid:{ a_coreAccountID }/webhook/platformservices?secret={ a_secret }&severity=low"
+                w_url = (
+                    f"https://watchman.api.manage.rackspace.com/v1/hybrid:{ a_coreAccountID }/webhook/platformservices?secret={ a_secret }&severity=low"
+                )
             else:
-                w_url = f"https://watchman.api.manage.rackspace.com/v1/hybrid:{ a_coreAccountID }/webhook/platformservices?secret={ a_secret }&severity=high"
+                w_url = (
+                    f"https://watchman.api.manage.rackspace.com/v1/hybrid:{ a_coreAccountID }/webhook/platformservices?secret={ a_secret }&severity=high"
+                )
             w_headers = {
                     "Accept": "application/json",
                     "Content-Type": "application/json"
             }
             w_body = f"""Severity: { a_severity }
-Instance: { alert.get('labels', {}).get('instance','UNKNOWN') }
-coreDeviceID: { alert.get('coreDeviceID', 'UNKNWON') }
+Instance: { alert.get('labels', {}).get('instance', 'UNKNOWN') }
+coreDeviceID: { alert.get('labels', {}).get('coreDeviceID', 'UNKNOWN') }
 coreAccountID: { a_coreAccountID }
 overseerID: { a_overseerID }
 Description: { a_description }
-Started at: { alert.get('startsAt','UNKNOWN') }
+Started at: { alert.get('startsAt', 'UNKNOWN') }
 Suppression Link: { settings.alert_proxy_config.am_v2_base_url }/#/alerts?filter=%7Balertname%3D%22{ a_name }%22%2C%20rackspace_com_coreAccountID%3D%22{ a_coreAccountID }%22%2C%20rackspace_com_overseerID%3D%22{ a_overseerID }%22%2C%20severity%3D%22{ a_severity }%22%7D
 """
             w_payload = {
@@ -158,6 +158,7 @@ Suppression Link: { settings.alert_proxy_config.am_v2_base_url }/#/alerts?filter
                 if settings.alert_proxy_config.create_ticket:
                     response = self._create_core_ticket(w_url, w_headers, w_payload)
                 else:
+                    current_app.logger.info("Ticket creation disabled; skipping post to Watchman API")
             except Exception as e:
                 current_app.logger.error(f"Uncaught error: {str(e)}")
                 continue

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -19,17 +19,29 @@ class Config:
             cls._instance._load_config() # Load configuration only once
         return cls._instance
 
+    def _resolve_env(self, value):
+        """Recursively replace environment variable placeholders in the config."""
+        if isinstance(value, str):
+            return os.path.expandvars(value)
+        if isinstance(value, dict):
+            return {k: self._resolve_env(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [self._resolve_env(v) for v in value]
+        return value
+
     def _load_config(self, filename="config.yaml"):
         """Loads configuration from a YAML file and processes it."""
         try:
             with open(filename, "r") as file:
-                config_data = yaml.safe_load(file)
+                raw_data = yaml.safe_load(file) or {}
         except FileNotFoundError:
             print(f"Error: Configuration file '{filename}' not found.")
-            config_data = {}  # Provide an empty dict if file not found
+            raw_data = {}  # Provide an empty dict if file not found
         except yaml.YAMLError as e:
             print(f"Error parsing YAML file '{filename}': {e}")
-            config_data = {}
+            raw_data = {}
+
+        config_data = self._resolve_env(raw_data)
 
         # Set attributes based on config_data
         for key, value in config_data.items():

--- a/src/config/config.yaml
+++ b/src/config/config.yaml
@@ -1,0 +1,11 @@
+debug: false
+app_debug: false
+logging:
+  log_level: INFO
+alert_proxy_config:
+  alert_verification: true
+  create_ticket: true
+  core_account_id: ${CORE_ACCOUNT_NUMBER}
+  core_overseer_id: ${OVERSEER_CORE_DEVICE_ID}
+  account_secret: ${ACCOUNT_SERVICE_TOKEN}
+  am_v2_base_url: ${ALERT_MANAGER_BASE_URL}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,25 @@
+import os
+import pathlib
+import sys
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+yaml = pytest.importorskip('yaml')
+
+from config.config import Config
+
+
+def test_env_substitution(tmp_path, monkeypatch):
+    data = {
+        'secret': '${TEST_SECRET}',
+        'nested': {'value': '${TEST_NESTED}'}
+    }
+    config_file = tmp_path / 'config.yaml'
+    config_file.write_text(yaml.dump(data))
+    monkeypatch.setenv('TEST_SECRET', 'hello')
+    monkeypatch.setenv('TEST_NESTED', 'world')
+    Config._instance = None
+    cfg = Config()
+    cfg._load_config(str(config_file))
+    assert cfg.secret == 'hello'
+    assert cfg.nested.value == 'world'

--- a/tests/test_process_alert.py
+++ b/tests/test_process_alert.py
@@ -1,0 +1,85 @@
+import json
+import pathlib
+import sys
+import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+pytest.importorskip('yaml')
+
+from alertproxy import create_app
+from apps.process_alert.process_alert import ProcessAlert
+
+
+def sample_payload():
+    return {
+        "status": "firing",
+        "commonLabels": {
+            "alertname": "TestAlert",
+            "overseerID": "ovr",
+            "coreAccountID": "acct"
+        },
+        "commonAnnotations": {
+            "summary": "summary",
+            "description": "description"
+        },
+        "alerts": [
+            {
+                "fingerprint": "abc",
+                "startsAt": "2020-01-01T00:00:00Z",
+                "labels": {"instance": "localhost", "severity": "critical"}
+            }
+        ]
+    }
+
+
+def test_severity_from_labels(monkeypatch):
+    app = create_app()
+    payload = sample_payload()
+    monkeypatch.setattr(ProcessAlert, "_is_alert_still_firing", lambda self, fp: True)
+    called = {}
+
+    def fake_create(self, url, headers, payload):
+        called["url"] = url
+
+    monkeypatch.setattr(ProcessAlert, "_create_core_ticket", fake_create)
+    with app.test_request_context('/alert/process', method='POST', json=payload):
+        ProcessAlert().post()
+    assert "severity=high" in called["url"]
+
+
+def test_request_id_absent(monkeypatch):
+    app = create_app()
+    payload = sample_payload()
+    monkeypatch.setattr(ProcessAlert, "_is_alert_still_firing", lambda self, fp: True)
+    monkeypatch.setattr(ProcessAlert, "_create_core_ticket", lambda self, u, h, p: None)
+    with app.test_request_context('/alert/process', method='POST', json=payload):
+        ProcessAlert().post()
+    assert 'request-id' not in payload['alerts'][0]['labels']
+
+
+def test_is_alert_still_firing(monkeypatch):
+    pa = ProcessAlert()
+
+    class Resp:
+        status_code = 200
+
+        def json(self):
+            return [{
+                'fingerprint': 'abc',
+                'status': {'state': 'active'}
+            }]
+
+    monkeypatch.setattr('apps.process_alert.process_alert.requests.get', lambda url: Resp())
+    assert pa._is_alert_still_firing('abc') is True
+
+    class RespInactive:
+        status_code = 200
+
+        def json(self):
+            return [{
+                'fingerprint': 'abc',
+                'status': {'state': 'inactive'}
+            }]
+
+    monkeypatch.setattr('apps.process_alert.process_alert.requests.get', lambda url: RespInactive())
+    assert pa._is_alert_still_firing('abc') is False


### PR DESCRIPTION
## Summary
- resolve request ID, severity, and overseer ID handling in alert processor
- expand env vars from config files and add default config
- run uwsgi in foreground and expose correct probe ports

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest` *(skipped: No module named 'yaml')*
- `apt-get install -y helm` *(failed: Unable to locate package helm)*
- `helm lint helm` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a38833d88332bb518770215df641